### PR TITLE
fix: google auth

### DIFF
--- a/Identity/Identity/Program.cs
+++ b/Identity/Identity/Program.cs
@@ -66,11 +66,11 @@ app.MapGet("/login", (HttpContext httpContext) =>
   // Challenge Google authentication, which will redirect to Google's login page
   return httpContext.ChallengeAsync(GoogleDefaults.AuthenticationScheme, new AuthenticationProperties
   {
-    RedirectUri = "/signin-google" // Set the redirect URI to your callback endpoint
+    RedirectUri = "/after-signin" // Set the redirect URI to your callback endpoint
   });
 });
 
-app.MapGet("/signin-google", async (HttpContext httpContext) =>
+app.MapGet("/after-signin", async (HttpContext httpContext) =>
 {
   var authenticateResult = await httpContext.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
 


### PR DESCRIPTION
It was really tricky.

`/signin-google` endpoint is created automatically by lib and in redirect URL you should setup the next URL where you will be redirected when 3rd party code from lib in `signin-google` endpoint will do all the magic

![image](https://github.com/podkolzzzin/AcademicHub/assets/1740940/6a006798-7056-4739-bf6c-ce7da6632f11)
